### PR TITLE
use ActiveSupport::HashWithIndifferentAccess if available

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,16 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (4.1.6)
+      i18n (~> 0.6, >= 0.6.9)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.1)
+      tzinfo (~> 1.1)
     diff-lcs (1.1.3)
+    i18n (0.6.11)
+    json (1.8.1)
+    minitest (5.4.2)
     rake (10.0.3)
     rspec (2.12.0)
       rspec-core (~> 2.12.0)
@@ -16,11 +25,15 @@ GEM
     rspec-expectations (2.12.1)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.12.1)
+    thread_safe (0.3.4)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   rake
   rspec
   settingslogic!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,16 +6,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.1.6)
-      i18n (~> 0.6, >= 0.6.9)
-      json (~> 1.7, >= 1.7.7)
-      minitest (~> 5.1)
-      thread_safe (~> 0.1)
-      tzinfo (~> 1.1)
+    activesupport (3.2.19)
+      i18n (~> 0.6, >= 0.6.4)
+      multi_json (~> 1.0)
     diff-lcs (1.1.3)
     i18n (0.6.11)
-    json (1.8.1)
-    minitest (5.4.2)
+    multi_json (1.10.1)
     rake (10.0.3)
     rspec (2.12.0)
       rspec-core (~> 2.12.0)
@@ -25,15 +21,12 @@ GEM
     rspec-expectations (2.12.1)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.12.1)
-    thread_safe (0.3.4)
-    tzinfo (1.2.2)
-      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport
+  activesupport (= 3.2.19)
   rake
   rspec
   settingslogic!

--- a/lib/settingslogic.rb
+++ b/lib/settingslogic.rb
@@ -100,7 +100,10 @@ class Settingslogic < Hash
       self.replace hash_or_file
     else
       file_contents = open(hash_or_file).read
-      hash = file_contents.empty? ? {} : YAML.load(ERB.new(file_contents).result).to_hash
+      hash = file_contents.empty? ? 
+        {}
+      :
+        YAML.load(ERB.new(file_contents).result)).to_hash.with_indifferent_access
       if self.class.namespace
         hash = hash[self.class.namespace] or return missing_key("Missing setting '#{self.class.namespace}' in #{hash_or_file}")
       end

--- a/lib/settingslogic.rb
+++ b/lib/settingslogic.rb
@@ -100,8 +100,8 @@ class Settingslogic < Hash
       self.replace hash_or_file
     else
       file_contents = open(hash_or_file).read
-      hash = file_contents.empty? ? {} : YAML.load(ERB.new(file_contents).result)).to_hash
-      hash = hash.with_indifferent_access if hash.respond_to? :with_indifferent_access
+      hash = file_contents.empty? ? {} : YAML.load(ERB.new(file_contents).result).to_hash
+      hash = hash.with_indifferent_access if hash.respond_to?(:with_indifferent_access)
       if self.class.namespace
         hash = hash[self.class.namespace] or return missing_key("Missing setting '#{self.class.namespace}' in #{hash_or_file}")
       end

--- a/lib/settingslogic.rb
+++ b/lib/settingslogic.rb
@@ -100,10 +100,8 @@ class Settingslogic < Hash
       self.replace hash_or_file
     else
       file_contents = open(hash_or_file).read
-      hash = file_contents.empty? ? 
-        {}
-      :
-        YAML.load(ERB.new(file_contents).result)).to_hash.with_indifferent_access
+      hash = file_contents.empty? ? {} : YAML.load(ERB.new(file_contents).result)).to_hash
+      hash = hash.with_indifferent_access if hash.respond_to? :with_indifferent_access
       if self.class.namespace
         hash = hash[self.class.namespace] or return missing_key("Missing setting '#{self.class.namespace}' in #{hash_or_file}")
       end

--- a/settingslogic.gemspec
+++ b/settingslogic.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
-  s.add_development_dependency 'activesupport'
+  s.add_development_dependency 'activesupport', '3.2.19'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/settingslogic.gemspec
+++ b/settingslogic.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
+  s.add_development_dependency 'activesupport'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/spec/settingslogic_spec.rb
+++ b/spec/settingslogic_spec.rb
@@ -200,7 +200,7 @@ describe "Settingslogic" do
     require 'active_support/core_ext/hash'
     Settings.reload!
     deep = Settings.setting1['deep']
-    deep.class.should == ActiveSupport::HashWithIndifferentAccess
+    deep.should be_kind_of(ActiveSupport::HashWithIndifferentAccess)
     deep['another'].should == 'my value'
     deep[:another].should == 'my value'
     #simulate un-requiring active_support/core_ext/hash
@@ -211,6 +211,7 @@ describe "Settingslogic" do
   it "should not accept keys as symbol or string if activesupport hash extensions not present" do
      Settings.reload!
      deep = Settings.setting1['deep']
+     deep.should be_kind_of(Hash)
      deep['another'].should == 'my value'
      deep[:another].should_not == 'my value'
   end

--- a/spec/settingslogic_spec.rb
+++ b/spec/settingslogic_spec.rb
@@ -4,11 +4,11 @@ describe "Settingslogic" do
   it "should access settings" do
     Settings.setting2.should == 5
   end
-  
+
   it "should access nested settings" do
     Settings.setting1.setting1_child.should == "saweet"
   end
-  
+
   it "should access settings in nested arrays" do
     Settings.array.first.name.should == "first"
   end
@@ -39,7 +39,7 @@ describe "Settingslogic" do
     Settings.language.haskell.paradigm.should == 'functional'
     Settings.language.smalltalk.paradigm.should == 'object oriented'
   end
-  
+
   it "should not collide with global methods" do
     Settings3.nested.collides.does.should == 'not either'
     Settings3[:nested] = 'fooey'
@@ -77,7 +77,7 @@ describe "Settingslogic" do
     end
     e.should_not be_nil
     e.message.should =~ /Missing setting 'erlang' in 'language' section/
-    
+
     Settings.language['erlang'].should be_nil
     Settings.language['erlang'] = 5
     Settings.language['erlang'].should == 5
@@ -168,14 +168,14 @@ describe "Settingslogic" do
   it "should allow a name setting to be overriden" do
     Settings.name.should == 'test'
   end
-  
+
   it "should allow symbolize_keys" do
     Settings.reload!
-    result = Settings.language.haskell.symbolize_keys 
+    result = Settings.language.haskell.symbolize_keys
     result.class.should == Hash
-    result.should == {:paradigm => "functional"} 
+    result.should == {:paradigm => "functional"}
   end
-  
+
   it "should allow symbolize_keys on nested hashes" do
     Settings.reload!
     result = Settings.language.symbolize_keys
@@ -194,6 +194,25 @@ describe "Settingslogic" do
   # masking bugs.
   it "should be a hash" do
     Settings.send(:instance).should be_is_a(Hash)
+  end
+
+  it "should accept keys as symbol or string if activesupport hash extensions present" do
+    require 'active_support/core_ext/hash'
+    Settings.reload!
+    deep = Settings.setting1['deep']
+    deep.class.should == ActiveSupport::HashWithIndifferentAccess
+    deep['another'].should == 'my value'
+    deep[:another].should == 'my value'
+    #simulate un-requiring active_support/core_ext/hash
+    Hash.send :remove_method, :with_indifferent_access
+    Settings.reload!
+  end
+
+  it "should not accept keys as symbol or string if activesupport hash extensions not present" do
+     Settings.reload!
+     deep = Settings.setting1['deep']
+     deep['another'].should == 'my value'
+     deep[:another].should_not == 'my value'
   end
 
   describe "#to_hash" do


### PR DESCRIPTION
similar to https://github.com/binarylogic/settingslogic/pull/52, but preserves 'classic' hash if method with_indifferent_access not available
