### PR TITLE
add after_load callback

### DIFF
--- a/lib/settingslogic.rb
+++ b/lib/settingslogic.rb
@@ -54,11 +54,18 @@ class Settingslogic < Hash
       load!
     end
 
+    def after_load( &blk )
+      @after_load = blk
+    end
+
     private
       def instance
         return @instance if @instance
         @instance = new
         create_accessors!
+        if @after_load
+          @after_load.call
+        end
         @instance
       end
 

--- a/spec/settings5.rb
+++ b/spec/settings5.rb
@@ -1,0 +1,6 @@
+class Settings5 < Settingslogic
+  source "#{File.dirname(__FILE__)}/settings.yml"
+  after_load {
+    setting1['setting1_child'] = 'supa saweet'
+  }
+end

--- a/spec/settingslogic_spec.rb
+++ b/spec/settingslogic_spec.rb
@@ -204,4 +204,8 @@ describe "Settingslogic" do
     end
   end
 
+  it 'should handle after_load' do
+    Settings5.setting1.setting1_child.should eql 'supa saweet'
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'settings'
 require 'settings2'
 require 'settings3'
 require 'settings4'
+require 'settings5'
 require 'settings_empty'
 
 # Needed to test Settings3


### PR DESCRIPTION
Adds an `after_load` callback to allows customization to the settings. I am using this patch on a system to layer in configuration from multiple sources.
