### PR TITLE
Added InstallGenerator for Rails

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -15,7 +15,11 @@ our apps, maybe you will enjoy it too.  Settingslogic works with Rails, Sinatra,
 
 == Installation
 
-  gem install settingslogic
+  gem "settinglogic"
+
+Optionally, you can run the generator, which will set up a Settings model with some useful defaults for you:
+
+  rails g settings:install
 
 == Usage
 

--- a/lib/generators/settings/USAGE
+++ b/lib/generators/settings/USAGE
@@ -1,0 +1,5 @@
+Description:
+  Generates the necessary files to get you up and running with Settingslogic gem
+
+Examples:
+  rails g settings:install

--- a/lib/generators/settings/install_generator.rb
+++ b/lib/generators/settings/install_generator.rb
@@ -1,0 +1,15 @@
+module Settings
+  module Generators
+    class InstallGenerator < ::Rails::Generators::Base
+      source_root File.expand_path("templates", __dir__)
+
+      def copy_configuration_file
+        copy_file "application.yml", "config/application.yml"
+      end
+
+      def copy_model_file
+        copy_file "settings.rb", "app/models/settings.rb"
+      end
+    end
+  end
+end

--- a/lib/generators/settings/templates/application.yml
+++ b/lib/generators/settings/templates/application.yml
@@ -1,0 +1,15 @@
+defaults: &defaults
+  cool:
+    saweet: nested settings
+  neat_setting: 24
+  awesome_setting: <%= "Did you know 5 + 5 = #{5 + 5}?" %>
+
+development:
+  <<: *defaults
+  neat_setting: 800
+
+test:
+  <<: *defaults
+
+production:
+  <<: *defaults

--- a/lib/generators/settings/templates/settings.rb
+++ b/lib/generators/settings/templates/settings.rb
@@ -1,0 +1,4 @@
+class Settings < Settingslogic
+  source Rails.root.join("config", "application.yml")
+  namespace Rails.env
+end


### PR DESCRIPTION
Tought this gem is very useful, it's troublesome to setup a little.
I've implemented InstallGenerator for Rails.

We can run the generator, which setup fast and easy:

```
$ bin/rails g settings:install
```

@goosetav Please review this request if you maintain this useful gem.