### PR TITLE
Add DotEnv lib

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+ayla_hmac.sso.scope="user/sso/v1"
+ayla_hmac.sso.salt="AYLA-SSO"
+ayla_hmac.sso.cutoff_time_in_sec=15

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ benchmarks/*
 .bundle
 vendor/bundle
 .rvmrc
+*.iml
+.idea/*

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
+gem 'dotenv' , '2.2.1'
 gemspec

--- a/lib/settingslogic.rb
+++ b/lib/settingslogic.rb
@@ -1,6 +1,8 @@
 require "yaml"
 require "erb"
 require 'open-uri'
+require 'dotenv'
+Dotenv.load
 
 # A simple settings solution using a YAML file. See README for more information.
 class Settingslogic < Hash

--- a/spec/settings.yml
+++ b/spec/settings.yml
@@ -26,3 +26,10 @@ array:
     name: first
   -
     name: second
+
+docker:
+  sso:
+    scope: "<%= ENV['ayla_hmac.sso.scope'] %>"
+    salt: "<%= ENV['ayla_hmac.sso.salt']  %>"
+    cutoff_time_in_sec: <%= ENV['ayla_hmac.sso.cutoff_time_in_sec']  %>
+

--- a/spec/settings5.rb
+++ b/spec/settings5.rb
@@ -1,0 +1,4 @@
+class Settings5 < Settingslogic
+  source "#{File.dirname(__FILE__)}/settings.yml"
+  namespace "docker"
+end

--- a/spec/settingslogic_spec.rb
+++ b/spec/settingslogic_spec.rb
@@ -204,4 +204,11 @@ describe "Settingslogic" do
     end
   end
 
+  it "should docker namespace using dotenv" do
+    Settings5.namespace.should == 'docker'
+    Settings5.sso.scope.should == "user/sso/v1"
+    Settings5.sso.salt.should == "AYLA-SSO"
+    Settings5.sso.cutoff_time_in_sec.should == 15
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'settings'
 require 'settings2'
 require 'settings3'
 require 'settings4'
+require 'settings5'
 require 'settings_empty'
 
 # Needed to test Settings3


### PR DESCRIPTION
This update adds [DotEnv Lib](https://github.com/bkeepers/dotenv) to the codebase.

Convenient if you plan to use Docker.