### PR TITLE
Fix aliases support.

### DIFF
--- a/lib/settingslogic.rb
+++ b/lib/settingslogic.rb
@@ -100,7 +100,7 @@ class Settingslogic < Hash
       self.replace hash_or_file
     else
       file_contents = open(hash_or_file).read
-      hash = file_contents.empty? ? {} : YAML.load(ERB.new(file_contents).result).to_hash
+      hash = file_contents.empty? ? {} : YAML.safe_load(ERB.new(file_contents).result, aliases: true).to_hash
       if self.class.namespace
         hash = hash[self.class.namespace] or return missing_key("Missing setting '#{self.class.namespace}' in #{hash_or_file}")
       end

--- a/lib/settingslogic.rb
+++ b/lib/settingslogic.rb
@@ -33,6 +33,10 @@ class Settingslogic < Hash
       @suppress_errors ||= value
     end
 
+    def permitted_classes(value = [])
+      @permitted_classes ||= value
+    end
+
     def [](key)
       instance.fetch(key.to_s, nil)
     end
@@ -100,7 +104,7 @@ class Settingslogic < Hash
       self.replace hash_or_file
     else
       file_contents = open(hash_or_file).read
-      hash = file_contents.empty? ? {} : YAML.safe_load(ERB.new(file_contents).result, aliases: true).to_hash
+      hash = file_contents.empty? ? {} : YAML.safe_load(ERB.new(file_contents).result, aliases: true, permitted_classes: self.class.permitted_classes).to_hash
       if self.class.namespace
         hash = hash[self.class.namespace] or return missing_key("Missing setting '#{self.class.namespace}' in #{hash_or_file}")
       end

--- a/spec/settings_with_alises.rb
+++ b/spec/settings_with_alises.rb
@@ -1,0 +1,4 @@
+class SettingsWithAliases < Settingslogic
+  source "#{File.dirname(__FILE__)}/settings_with_alises.yml"
+  namespace "test"
+end

--- a/spec/settings_with_alises.yml
+++ b/spec/settings_with_alises.yml
@@ -1,0 +1,11 @@
+defaults: &defaults
+  a: 1
+  b: 2
+
+development:
+  <<: *defaults
+  a: 2
+
+test:
+  <<: *defaults
+  b: 3

--- a/spec/settingslogic_spec.rb
+++ b/spec/settingslogic_spec.rb
@@ -190,6 +190,10 @@ describe "Settingslogic" do
     SettingsEmpty.keys.should eql([])
   end
 
+  it "shuld work with aliases" do
+    SettingsWithAliases.b.should eql(3)
+  end
+
   # Put this test last or else call to .instance will load @instance,
   # masking bugs.
   it "should be a hash" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require 'settings2'
 require 'settings3'
 require 'settings4'
 require 'settings_empty'
+require 'settings_with_alises'
 
 # Needed to test Settings3
 Object.send :define_method, 'collides' do


### PR DESCRIPTION
Ruby 3.1 using Psych 4,
which breaks parsing YAML with aliases Psych::BadAlias