### PR TITLE
Ruby 3.1 support

### DIFF
--- a/lib/settingslogic.rb
+++ b/lib/settingslogic.rb
@@ -100,7 +100,7 @@ class Settingslogic < Hash
       self.replace hash_or_file
     else
       file_contents = open(hash_or_file).read
-      hash = file_contents.empty? ? {} : YAML.load(ERB.new(file_contents).result).to_hash
+      hash = file_contents.empty? ? {} : yaml_load(file_contents)
       if self.class.namespace
         hash = hash[self.class.namespace] or return missing_key("Missing setting '#{self.class.namespace}' in #{hash_or_file}")
       end
@@ -187,5 +187,20 @@ class Settingslogic < Hash
     return nil if self.class.suppress_errors
 
     raise MissingSetting, msg
+  end
+  
+  private
+  
+  def yaml_load file_contents
+    erb_content = ERB.new(file_contents).result
+    
+    # Ruby 3.1 with Psych 4 allows yaml-aliases only in direct manner
+    yaml_content = if defined?(Psych::VERSION) && Psych::VERSION > '4.0'
+      YAML.safe_load(erb_content, aliases: true)
+    else
+      YAML.safe_load(erb_content, [], [], true)
+    end
+  
+    yaml_content.to_hash
   end
 end


### PR DESCRIPTION
YAML.load of file with yaml-aliases will raise an error in ruby 3.1 because of Psych 4 doesn't allow to use aliases.
Psych 4 is require to use aliases in direct manner like so:

```ruby
YAML.safe_load(erb_content, aliases: true)
```

https://github.com/mperham/sidekiq/issues/5140#issuecomment-1020522135